### PR TITLE
feat: add adder_cin_global flag

### DIFF
--- a/parmys/parmys-plugin/parmys.cc
+++ b/parmys/parmys-plugin/parmys.cc
@@ -878,6 +878,8 @@ struct ParMYSPass : public Pass {
         global_args.exact_mults = -1;
         global_args.mults_ratio = -1.0;
 
+        set_default_config();
+
         log_header(design, "Starting parmys pass.\n");
 
         size_t argidx;
@@ -918,6 +920,10 @@ struct ParMYSPass : public Pass {
                 global_args.mults_ratio = atof(args[++argidx].c_str());
                 continue;
             }
+            if (args[argidx] == "-adder_cin_global") {
+                configuration.adder_cin_global = true;
+                continue;
+            }
         }
         extra_args(args, argidx, design);
 
@@ -935,7 +941,6 @@ struct ParMYSPass : public Pass {
         }
 
         mixer = new HardSoftLogicMixer();
-        set_default_config();
 
         if (global_args.mults_ratio >= 0.0 && global_args.mults_ratio <= 1.0) {
             delete mixer->_opts[MULTIPLY];

--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -66,7 +66,7 @@ techmap -map +/parmys/aldffe2dff.v
 
 opt -full
 
-parmys -a QQQ -nopass -c CCC YYY
+parmys -a QQQ -nopass -c CCC ADDERCINGLOBAL
 
 opt -full
 

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -54,7 +54,8 @@ def init_script_file(
     architecture_file_path,
     odin_config_full_path,
     include_dir='.',
-    top_module='-auto-top'
+    top_module='-auto-top',
+    adder_cin_global=False
 ):
     """initializing the raw yosys script file"""
     # specify the input files type
@@ -74,6 +75,7 @@ def init_script_file(
             "QQQ": architecture_file_path,
             "SEARCHPATH": include_dir,
             "TOPMODULE": top_module,
+            "ADDERCINGLOBAL": "-adder_cin_global" if adder_cin_global else ""
         },
     )
 
@@ -227,6 +229,11 @@ def run(
             top_module = '-top ' + parmys_args['topmodule']
         del parmys_args['topmodule']
 
+    adder_cin_global = False
+    if ('adder_cin_global' in parmys_args):
+        adder_cin_global = parmys_args['adder_cin_global']
+        del parmys_args['adder_cin_global']
+    
     odin_base_config = str(vtr.paths.odin_cfg_path)
 
     # Copy the config file
@@ -251,7 +258,8 @@ def run(
         architecture_file_path,
         odin_config_full_path,
         include_dir=include_dir,
-        top_module=top_module
+        top_module=top_module,
+        adder_cin_global=adder_cin_global
     )
 
     # set the parser

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -295,7 +295,7 @@ def vtr_command_argparser(prog=None):
         help="Tells ODIN II the adder type used in this configuration",
     )
     odin.add_argument(
-        "-adder_cin_global",
+        "-adder_cin_global_odin",
         default=False,
         action="store_true",
         dest="adder_cin_global",
@@ -383,6 +383,14 @@ def vtr_command_argparser(prog=None):
         default=os.getcwd(),
         dest='searchpath',
         help='search path for verilog files'
+    )
+    parmys.add_argument(
+        "-adder_cin_global",
+        default=False,
+        action="store_true",
+        dest="adder_cin_global",
+        help="Tells Parmys to connect the first cin in an adder/subtractor"
+        + "chain to a global gnd/vdd net.",
     )
     #
     # VPR arguments
@@ -748,6 +756,7 @@ def process_parmys_args(args):
     parmys_args["parser"] = args.parser
     parmys_args["topmodule"] = args.topmodule
     parmys_args['searchpath'] = args.searchpath
+    parmys_args["adder_cin_global"] = args.adder_cin_global
     return parmys_args
 
 


### PR DESCRIPTION
This adds "-adder_cin_global" to VTR, which will connect the start of adder chains to global GND/Vdd if set, instead of a default dummy adder.